### PR TITLE
fix(agent): remove duplicate greeting on session start

### DIFF
--- a/voice/simple_agent.py
+++ b/voice/simple_agent.py
@@ -567,7 +567,7 @@ async def entrypoint(ctx: JobContext):
             userdata.add_transcript("user", ev.transcript)
             asyncio.create_task(broadcast_transcript("user", ev.transcript))
 
-    session.say("안녕하세요, 어르신. 오늘 어떻게 지내셨어요?")
+    # Greeting is handled in ElderlyCompanionAgent.on_enter()
 
     async def poll_for_admin():
         """Periodically check for admin presence since events may not fire."""


### PR DESCRIPTION
## Summary
- 통화 시작 시 인사가 2번 되는 버그 수정

## Changes
- simple_agent.py에서 중복 session.say() 호출 제거
- 인사는 ElderlyCompanionAgent.on_enter()에서 처리

Related: ops-api#79