### PR TITLE
[Refactor] 에이전트 대화 저장 로직 분리 및 Redis Pub/Sub 기반 이벤트 아키텍처 도입

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -5,6 +5,12 @@ services:
     network_mode: host
     restart: unless-stopped
     command: ["python", "voice/simple_agent.py", "start"]
+    healthcheck:
+      test: ["CMD-SHELL", "pgrep -f simple_agent.py || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
 
   video-agent:
     build: .
@@ -13,6 +19,12 @@ services:
     restart: unless-stopped
     # dockefile에 있는 CMD을 override / 덮어쓴다
     command: ["python", "voice/video-agent.py", "start"]
+    healthcheck:
+      test: ["CMD-SHELL", "pgrep -f video-agent.py || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
 
   transcript-storage:
     build: .
@@ -20,3 +32,12 @@ services:
     network_mode: host
     restart: unless-stopped
     command: ["python", "voice/transcript_storage_service.py"]
+    healthcheck:
+      test: ["CMD-SHELL", "pgrep -f transcript_storage_service.py || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+    depends_on:
+      - voice-agent
+      - video-agent

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -13,3 +13,10 @@ services:
     restart: unless-stopped
     # dockefile에 있는 CMD을 override / 덮어쓴다
     command: ["python", "voice/video-agent.py", "start"]
+
+  transcript-storage:
+    build: .
+    env_file: ./agent.env
+    network_mode: host
+    restart: unless-stopped
+    command: ["python", "voice/transcript_storage_service.py"]

--- a/voice/constants.py
+++ b/voice/constants.py
@@ -1,0 +1,20 @@
+"""
+Shared constants for voice agent services.
+
+Centralized configuration to prevent duplication and inconsistencies.
+"""
+
+# Redis Pub/Sub channel names
+TRANSCRIPT_CHANNEL = "transcripts"
+TTS_CHANNEL = "tts_transcripts"
+CALL_END_CHANNEL = "call_end"
+
+# Timeouts (seconds)
+TIMEOUT_CALL_CONTEXT = 5.0
+TIMEOUT_RAG_INDEXING = 5.0
+TIMEOUT_CALL_END = 5.0
+
+# Redis retry configuration
+REDIS_MAX_RETRIES = 5
+REDIS_RETRY_DELAY = 2.0  # seconds
+REDIS_RETRY_BACKOFF = 2.0  # exponential backoff multiplier

--- a/voice/simple_agent.py
+++ b/voice/simple_agent.py
@@ -30,6 +30,14 @@ from livekit.plugins import aws, silero
 from config import validate_env_vars, get_optional_config, ConfigError
 from agents.elderly_companion import ElderlyCompanionAgent, CallDirection
 from userdata import SessionUserdata
+from constants import (
+    TRANSCRIPT_CHANNEL,
+    CALL_END_CHANNEL,
+    TIMEOUT_CALL_CONTEXT,
+    REDIS_MAX_RETRIES,
+    REDIS_RETRY_DELAY,
+    REDIS_RETRY_BACKOFF,
+)
 
 # Load environment variables
 load_dotenv(dotenv_path=Path(__file__).parent.parent / ".env")
@@ -57,13 +65,9 @@ logger = logging.getLogger(__name__)
 redis_client = None
 redis_init_lock = asyncio.Lock()
 
-# Redis Pub/Sub channels
-TRANSCRIPT_CHANNEL = "transcripts"
-CALL_END_CHANNEL = "call_end"
-
 
 async def init_redis_client():
-    """Initialize Redis client asynchronously for publishing events."""
+    """Initialize Redis client asynchronously with retry logic."""
     global redis_client
     if redis_client:
         return
@@ -72,19 +76,28 @@ async def init_redis_client():
         if redis_client:
             return
 
-        try:
-            redis_client = redis_async.from_url(
-                env_config["REDIS_URL"],
-                decode_responses=True,
-            )
-            await redis_client.ping()
-            logger.info("Successfully connected to Redis for Pub/Sub")
-        except redis.exceptions.ConnectionError as e:
-            logger.error(f"Failed to connect to Redis: {e}")
-            redis_client = None
-        except Exception as e:
-            logger.error(f"An unexpected error occurred with Redis: {e}")
-            redis_client = None
+        for attempt in range(REDIS_MAX_RETRIES):
+            try:
+                redis_client = redis_async.from_url(
+                    env_config["REDIS_URL"],
+                    decode_responses=True,
+                )
+                await redis_client.ping()
+                logger.info("Successfully connected to Redis for Pub/Sub")
+                return
+            except redis.exceptions.ConnectionError as e:
+                retry_delay = REDIS_RETRY_DELAY * (REDIS_RETRY_BACKOFF ** attempt)
+                logger.warning(f"Redis connection attempt {attempt + 1}/{REDIS_MAX_RETRIES} failed: {e}")
+                if attempt < REDIS_MAX_RETRIES - 1:
+                    logger.info(f"Retrying in {retry_delay}s...")
+                    await asyncio.sleep(retry_delay)
+                else:
+                    logger.error("Failed to connect to Redis after all retries")
+                    redis_client = None
+            except Exception as e:
+                logger.error(f"Unexpected error connecting to Redis: {e}")
+                redis_client = None
+                break
 
 
 # API configuration
@@ -94,9 +107,6 @@ if not API_BASE:
     API_BASE = "http://localhost:3000"
 
 API_INTERNAL_TOKEN = os.getenv("API_INTERNAL_TOKEN")
-
-# Timeouts (seconds)
-TIMEOUT_CALL_CONTEXT = 5.0
 
 # Create AgentServer instance
 server = AgentServer()
@@ -176,21 +186,34 @@ def _get_auth_headers() -> dict:
 
 
 async def publish_call_end_event(call_id: str, ward_id: str):
-    """Publish call end event to Redis Pub/Sub for storage service to handle."""
-    if not redis_client:
-        logger.warning("Redis client not available, cannot publish call_end event")
-        return
+    """Publish call end event to Redis Pub/Sub with fallback to API."""
+    event = {
+        "call_id": call_id,
+        "ward_id": ward_id,
+        "timestamp": datetime.utcnow().isoformat(),
+    }
 
+    # Try Redis Pub/Sub first
+    if redis_client:
+        try:
+            await redis_client.publish(CALL_END_CHANNEL, json.dumps(event, ensure_ascii=False))
+            logger.info(f"Published call_end event to Redis: call={call_id}")
+            return
+        except Exception as e:
+            logger.error(f"Failed to publish call_end to Redis: {e}, falling back to direct API call")
+
+    # Fallback: Direct API call
     try:
-        event = {
-            "call_id": call_id,
-            "ward_id": ward_id,
-            "timestamp": datetime.utcnow().isoformat(),
-        }
-        await redis_client.publish(CALL_END_CHANNEL, json.dumps(event, ensure_ascii=False))
-        logger.info(f"Published call_end event: call={call_id}")
+        async with httpx.AsyncClient() as client:
+            await client.post(
+                f"{API_BASE}/v1/calls/end",
+                json={"callId": call_id, "wardId": ward_id},
+                headers=_get_auth_headers(),
+                timeout=5.0,
+            )
+            logger.info(f"Call end notified via API fallback: call={call_id}")
     except Exception as e:
-        logger.error(f"Failed to publish call_end event: {e}")
+        logger.error(f"Failed to notify call end via API fallback: {e}")
 
 
 async def fetch_call_context(room_name: str) -> Optional[dict]:
@@ -268,6 +291,9 @@ async def entrypoint(ctx: JobContext):
         call_direction=call_direction,
     )
 
+    # Track background tasks to prevent memory leaks
+    background_tasks = set()
+
     # Create agent session with userdata
     session = AgentSession[SessionUserdata](
         userdata=userdata,
@@ -284,23 +310,47 @@ async def entrypoint(ctx: JobContext):
     )
 
     async def publish_transcript_event(speaker_type: str, text: str):
-        """Publish transcript event to Redis Pub/Sub for storage service."""
-        if not redis_client:
-            logger.warning("Redis client not available, cannot publish transcript event")
-            return
+        """Publish transcript event to Redis Pub/Sub with fallback to direct storage."""
+        timestamp = datetime.utcnow().isoformat()
+        event = {
+            "call_id": call_id,
+            "speaker": speaker_type,
+            "text": text,
+            "timestamp": timestamp,
+        }
 
-        try:
-            timestamp = datetime.utcnow().isoformat()
-            event = {
-                "call_id": call_id,
-                "speaker": speaker_type,
-                "text": text,
-                "timestamp": timestamp,
-            }
-            await redis_client.publish(TRANSCRIPT_CHANNEL, json.dumps(event, ensure_ascii=False))
-            logger.debug(f"Published transcript: {speaker_type} - {text}")
-        except Exception as e:
-            logger.error(f"Failed to publish transcript event: {e}")
+        # Try Redis Pub/Sub first
+        if redis_client:
+            try:
+                await redis_client.publish(TRANSCRIPT_CHANNEL, json.dumps(event, ensure_ascii=False))
+                logger.debug(f"Published transcript to Redis: {speaker_type} - {text}")
+                return
+            except Exception as e:
+                logger.error(f"Failed to publish transcript to Redis: {e}, falling back to direct storage")
+
+        # Fallback: Direct Redis storage (without Pub/Sub)
+        if redis_client:
+            try:
+                transcript_entry = {
+                    "speaker": speaker_type,
+                    "text": text,
+                    "timestamp": timestamp,
+                }
+                redis_key = f"call:{call_id}:transcripts"
+                pipe = redis_client.pipeline()
+                pipe.rpush(redis_key, json.dumps(transcript_entry, ensure_ascii=False))
+                pipe.expire(redis_key, 3600 * 24)  # 24 hours
+                await pipe.execute()
+                logger.debug(f"Stored transcript directly to Redis: {speaker_type} - {text}")
+            except Exception as e:
+                logger.error(f"Failed to store transcript directly: {e}")
+
+    def create_tracked_task(coro):
+        """Create a task and track it to prevent memory leaks."""
+        task = asyncio.create_task(coro)
+        background_tasks.add(task)
+        task.add_done_callback(background_tasks.discard)
+        return task
 
     # Event: User transcript received
     @session.on("user_input_transcribed")
@@ -311,7 +361,7 @@ async def entrypoint(ctx: JobContext):
             userdata.add_transcript("user", ev.transcript)
             logger.debug(f"User transcript: {ev.transcript}")
             # Publish to storage service
-            asyncio.create_task(publish_transcript_event("user", ev.transcript))
+            create_tracked_task(publish_transcript_event("user", ev.transcript))
 
     # Event: Agent speech
     @session.on("agent_speech_committed")
@@ -322,7 +372,7 @@ async def entrypoint(ctx: JobContext):
             userdata.add_transcript("agent", ev.content)
             logger.debug(f"Agent response: {ev.content}")
             # Publish to storage service (Redis)
-            asyncio.create_task(publish_transcript_event("agent", ev.content))
+            create_tracked_task(publish_transcript_event("agent", ev.content))
 
     session_end_event = asyncio.Event()
     post_session_task = None
@@ -377,9 +427,9 @@ async def entrypoint(ctx: JobContext):
                 if content and content.strip():
                     userdata.add_transcript("agent", content)
                     # Publish to Redis for storage
-                    asyncio.create_task(publish_transcript_event("agent", content))
+                    create_tracked_task(publish_transcript_event("agent", content))
                     # Broadcast to frontend
-                    asyncio.create_task(broadcast_transcript("agent", content))
+                    create_tracked_task(broadcast_transcript("agent", content))
         except Exception as e:
             logger.error(f"Error in conversation_item_added handler: {e}")
 
@@ -540,7 +590,7 @@ async def entrypoint(ctx: JobContext):
             return
         if ev.is_final:
             userdata.add_transcript("user", ev.transcript)
-            asyncio.create_task(broadcast_transcript("user", ev.transcript))
+            create_tracked_task(broadcast_transcript("user", ev.transcript))
 
     # Greeting is handled in ElderlyCompanionAgent.on_enter()
 

--- a/voice/simple_agent.py
+++ b/voice/simple_agent.py
@@ -53,13 +53,17 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-# Redis client (async) initialization
+# Redis client (async) initialization for Pub/Sub
 redis_client = None
 redis_init_lock = asyncio.Lock()
 
+# Redis Pub/Sub channels
+TRANSCRIPT_CHANNEL = "transcripts"
+CALL_END_CHANNEL = "call_end"
+
 
 async def init_redis_client():
-    """Initialize Redis client asynchronously to avoid blocking the event loop."""
+    """Initialize Redis client asynchronously for publishing events."""
     global redis_client
     if redis_client:
         return
@@ -74,7 +78,7 @@ async def init_redis_client():
                 decode_responses=True,
             )
             await redis_client.ping()
-            logger.info("Successfully connected to Redis")
+            logger.info("Successfully connected to Redis for Pub/Sub")
         except redis.exceptions.ConnectionError as e:
             logger.error(f"Failed to connect to Redis: {e}")
             redis_client = None
@@ -92,11 +96,7 @@ if not API_BASE:
 API_INTERNAL_TOKEN = os.getenv("API_INTERNAL_TOKEN")
 
 # Timeouts (seconds)
-TIMEOUT_RAG_INDEXING = 5.0
-TIMEOUT_CALL_ANALYSIS = 5.0
 TIMEOUT_CALL_CONTEXT = 5.0
-TIMEOUT_CALL_END = 5.0
-TIMEOUT_POST_SESSION = 10.0
 
 # Create AgentServer instance
 server = AgentServer()
@@ -175,37 +175,22 @@ def _get_auth_headers() -> dict:
     return headers
 
 
-async def trigger_rag_indexing(call_id: str, ward_id: str):
-    """Trigger RAG indexing after session ends."""
-    try:
-        async with httpx.AsyncClient() as client:
-            await client.post(
-                f"{API_BASE}/v1/rag/index",
-                json={
-                    "callId": call_id,
-                    "wardId": ward_id,
-                },
-                headers=_get_auth_headers(),
-                timeout=TIMEOUT_RAG_INDEXING,
-            )
-            logger.info(f"RAG indexing triggered: call={call_id}")
-    except Exception as e:
-        logger.error(f"RAG indexing trigger failed: {e}")
+async def publish_call_end_event(call_id: str, ward_id: str):
+    """Publish call end event to Redis Pub/Sub for storage service to handle."""
+    if not redis_client:
+        logger.warning("Redis client not available, cannot publish call_end event")
+        return
 
-
-async def trigger_call_end(call_id: str):
-    """Inform API that the call ended so it can finalize state and summaries."""
     try:
-        async with httpx.AsyncClient() as client:
-            await client.post(
-                f"{API_BASE}/v1/calls/end",
-                json={"callId": call_id},
-                headers=_get_auth_headers(),
-                timeout=TIMEOUT_CALL_END,
-            )
-            logger.info(f"Call end notified: call={call_id}")
+        event = {
+            "call_id": call_id,
+            "ward_id": ward_id,
+            "timestamp": datetime.utcnow().isoformat(),
+        }
+        await redis_client.publish(CALL_END_CHANNEL, json.dumps(event, ensure_ascii=False))
+        logger.info(f"Published call_end event: call={call_id}")
     except Exception as e:
-        logger.error(f"Call end trigger failed: {e}")
+        logger.error(f"Failed to publish call_end event: {e}")
 
 
 async def fetch_call_context(room_name: str) -> Optional[dict]:
@@ -298,29 +283,24 @@ async def entrypoint(ctx: JobContext):
         max_endpointing_delay=5.0,
     )
 
-    async def add_transcript_to_redis(speaker_type: str, text: str):
-        """Helper to create and push transcript to Redis."""
+    async def publish_transcript_event(speaker_type: str, text: str):
+        """Publish transcript event to Redis Pub/Sub for storage service."""
         if not redis_client:
-            logger.warning("Redis client not available, skipping transcript storage.")
+            logger.warning("Redis client not available, cannot publish transcript event")
             return
 
         try:
             timestamp = datetime.utcnow().isoformat()
-            transcript_entry = {
+            event = {
+                "call_id": call_id,
                 "speaker": speaker_type,
                 "text": text,
                 "timestamp": timestamp,
             }
-            redis_key = f"call:{call_id}:transcripts"
-            pipe = redis_client.pipeline()
-            pipe.rpush(redis_key, json.dumps(transcript_entry, ensure_ascii=False))
-            pipe.expire(redis_key, 3600 * 24)  # 24 hours
-            await pipe.execute()
-            logger.debug(f"Saved to Redis: {speaker_type} - {text}")
-        except redis.exceptions.RedisError as e:
-            logger.error(f"Failed to save transcript to Redis: {e}")
+            await redis_client.publish(TRANSCRIPT_CHANNEL, json.dumps(event, ensure_ascii=False))
+            logger.debug(f"Published transcript: {speaker_type} - {text}")
         except Exception as e:
-            logger.error(f"An unexpected error occurred while saving to Redis: {e}")
+            logger.error(f"Failed to publish transcript event: {e}")
 
     # Event: User transcript received
     @session.on("user_input_transcribed")
@@ -330,8 +310,8 @@ async def entrypoint(ctx: JobContext):
             # Store in-memory
             userdata.add_transcript("user", ev.transcript)
             logger.debug(f"User transcript: {ev.transcript}")
-            # Store in Redis
-            asyncio.create_task(add_transcript_to_redis("user", ev.transcript))
+            # Publish to storage service
+            asyncio.create_task(publish_transcript_event("user", ev.transcript))
 
     # Event: Agent speech
     @session.on("agent_speech_committed")
@@ -341,8 +321,8 @@ async def entrypoint(ctx: JobContext):
             # Store in-memory
             userdata.add_transcript("agent", ev.content)
             logger.debug(f"Agent response: {ev.content}")
-            # Store in Redis
-            asyncio.create_task(add_transcript_to_redis("agent", ev.content))
+            # Publish to storage service (Redis)
+            asyncio.create_task(publish_transcript_event("agent", ev.content))
 
     session_end_event = asyncio.Event()
     post_session_task = None
@@ -396,6 +376,8 @@ async def entrypoint(ctx: JobContext):
                 
                 if content and content.strip():
                     userdata.add_transcript("agent", content)
+                    # Publish to Redis for storage
+                    asyncio.create_task(publish_transcript_event("agent", content))
                     # Broadcast to frontend
                     asyncio.create_task(broadcast_transcript("agent", content))
         except Exception as e:
@@ -406,8 +388,8 @@ async def entrypoint(ctx: JobContext):
     @session.on("session_end")
     def on_session_end(report):
         """
-        Handle session end - trigger analysis and indexing.
-        
+        Handle session end - publish call_end event for storage service.
+
         SessionReport contains:
         - session_id
         - duration
@@ -417,22 +399,12 @@ async def entrypoint(ctx: JobContext):
             logger.info(f"Session ended: {report.session_id if hasattr(report, 'session_id') else call_id}")
             logger.info(f"Total transcripts: {len(userdata.transcripts)}")
 
-            # Run post-session tasks with timeout
-            tasks = [
-                trigger_call_end(call_id),
-                trigger_rag_indexing(call_id, ward_id),
-            ]
-
+            # Publish call_end event to storage service
             try:
-                await asyncio.wait_for(
-                    asyncio.gather(*tasks, return_exceptions=True),
-                    timeout=TIMEOUT_POST_SESSION,
-                )
-                logger.info("Post-session tasks completed")
-            except asyncio.TimeoutError:
-                logger.warning("Post-session tasks timed out")
+                await publish_call_end_event(call_id, ward_id)
+                logger.info("Call end event published")
             except Exception as e:
-                logger.error(f"Post-session tasks failed: {e}")
+                logger.error(f"Failed to publish call_end event: {e}")
 
         nonlocal post_session_task
         post_session_task = asyncio.create_task(_run_post_session_tasks())

--- a/voice/transcript_storage_service.py
+++ b/voice/transcript_storage_service.py
@@ -19,6 +19,17 @@ import httpx
 import redis.asyncio as redis_async
 from dotenv import load_dotenv
 
+from constants import (
+    TRANSCRIPT_CHANNEL,
+    TTS_CHANNEL,
+    CALL_END_CHANNEL,
+    TIMEOUT_RAG_INDEXING,
+    TIMEOUT_CALL_END,
+    REDIS_MAX_RETRIES,
+    REDIS_RETRY_DELAY,
+    REDIS_RETRY_BACKOFF,
+)
+
 # Load environment variables
 load_dotenv(dotenv_path=Path(__file__).parent.parent / ".env")
 
@@ -32,17 +43,10 @@ logger = logging.getLogger(__name__)
 
 # Redis configuration
 REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379")
-TRANSCRIPT_CHANNEL = "transcripts"
-TTS_CHANNEL = "tts_transcripts"
-CALL_END_CHANNEL = "call_end"
 
 # API configuration
 API_BASE = os.getenv("API_BASE_URL", "http://localhost:3000")
 API_INTERNAL_TOKEN = os.getenv("API_INTERNAL_TOKEN")
-
-# Timeouts
-TIMEOUT_RAG_INDEXING = 5.0
-TIMEOUT_CALL_END = 5.0
 
 
 def _get_auth_headers() -> dict:
@@ -171,52 +175,79 @@ async def handle_call_end_message(message: dict):
         logger.error(f"Error handling call_end message: {e}")
 
 
+async def connect_to_redis_with_retry():
+    """Connect to Redis with exponential backoff retry logic."""
+    for attempt in range(REDIS_MAX_RETRIES):
+        try:
+            redis_client = redis_async.from_url(REDIS_URL, decode_responses=True)
+            await redis_client.ping()
+            logger.info(f"Successfully connected to Redis (attempt {attempt + 1}/{REDIS_MAX_RETRIES})")
+            return redis_client
+        except Exception as e:
+            retry_delay = REDIS_RETRY_DELAY * (REDIS_RETRY_BACKOFF ** attempt)
+            logger.warning(f"Redis connection attempt {attempt + 1}/{REDIS_MAX_RETRIES} failed: {e}")
+            if attempt < REDIS_MAX_RETRIES - 1:
+                logger.info(f"Retrying in {retry_delay}s...")
+                await asyncio.sleep(retry_delay)
+            else:
+                logger.error("Failed to connect to Redis after all retries")
+                raise
+
+
 async def main():
-    """Main service loop."""
+    """Main service loop with automatic reconnection."""
     logger.info("Starting Transcript Storage Service...")
     logger.info(f"Connecting to Redis: {REDIS_URL}")
 
-    # Connect to Redis
-    redis_client = None
-    pubsub = None
+    while True:
+        redis_client = None
+        pubsub = None
 
-    try:
-        redis_client = redis_async.from_url(REDIS_URL, decode_responses=True)
-        await redis_client.ping()
-        logger.info("Successfully connected to Redis")
+        try:
+            # Connect to Redis with retry logic
+            redis_client = await connect_to_redis_with_retry()
 
-        # Subscribe to channels
-        pubsub = redis_client.pubsub()
-        await pubsub.subscribe(TRANSCRIPT_CHANNEL, TTS_CHANNEL, CALL_END_CHANNEL)
-        logger.info(f"Subscribed to channels: {TRANSCRIPT_CHANNEL}, {TTS_CHANNEL}, {CALL_END_CHANNEL}")
+            # Subscribe to channels
+            pubsub = redis_client.pubsub()
+            await pubsub.subscribe(TRANSCRIPT_CHANNEL, TTS_CHANNEL, CALL_END_CHANNEL)
+            logger.info(f"Subscribed to channels: {TRANSCRIPT_CHANNEL}, {TTS_CHANNEL}, {CALL_END_CHANNEL}")
 
-        # Listen for messages
-        async for message in pubsub.listen():
-            if message["type"] != "message":
-                continue
+            # Listen for messages
+            async for message in pubsub.listen():
+                if message["type"] != "message":
+                    continue
 
-            channel = message["channel"]
+                channel = message["channel"]
 
-            if channel == TRANSCRIPT_CHANNEL:
-                await handle_transcript_message(redis_client, message)
-            elif channel == TTS_CHANNEL:
-                await handle_tts_message(redis_client, message)
-            elif channel == CALL_END_CHANNEL:
-                await handle_call_end_message(message)
+                if channel == TRANSCRIPT_CHANNEL:
+                    await handle_transcript_message(redis_client, message)
+                elif channel == TTS_CHANNEL:
+                    await handle_tts_message(redis_client, message)
+                elif channel == CALL_END_CHANNEL:
+                    await handle_call_end_message(message)
 
-    except KeyboardInterrupt:
-        logger.info("Service stopped by user")
-    except Exception as e:
-        logger.error(f"Fatal error: {e}")
-        sys.exit(1)
-    finally:
-        # Cleanup
-        if pubsub:
-            await pubsub.unsubscribe(TRANSCRIPT_CHANNEL, TTS_CHANNEL, CALL_END_CHANNEL)
-            await pubsub.close()
-        if redis_client:
-            await redis_client.close()
-        logger.info("Service shutdown complete")
+        except KeyboardInterrupt:
+            logger.info("Service stopped by user")
+            break
+        except Exception as e:
+            logger.error(f"Connection error: {e}")
+            logger.info(f"Reconnecting in {REDIS_RETRY_DELAY}s...")
+            await asyncio.sleep(REDIS_RETRY_DELAY)
+        finally:
+            # Cleanup
+            if pubsub:
+                try:
+                    await pubsub.unsubscribe(TRANSCRIPT_CHANNEL, TTS_CHANNEL, CALL_END_CHANNEL)
+                    await pubsub.close()
+                except Exception as e:
+                    logger.error(f"Error closing pubsub: {e}")
+            if redis_client:
+                try:
+                    await redis_client.close()
+                except Exception as e:
+                    logger.error(f"Error closing redis client: {e}")
+
+    logger.info("Service shutdown complete")
 
 
 if __name__ == "__main__":

--- a/voice/transcript_storage_service.py
+++ b/voice/transcript_storage_service.py
@@ -1,0 +1,233 @@
+"""
+Transcript Storage Service - Handles storing and post-processing call transcripts.
+
+This service:
+- Subscribes to Redis Pub/Sub for transcript events
+- Stores transcripts to Redis
+- Triggers RAG indexing when calls end
+- Triggers call analysis
+"""
+import asyncio
+import json
+import logging
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import httpx
+import redis.asyncio as redis_async
+from dotenv import load_dotenv
+
+# Load environment variables
+load_dotenv(dotenv_path=Path(__file__).parent.parent / ".env")
+
+# Setup logging
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
+logging.basicConfig(
+    level=getattr(logging, LOG_LEVEL, logging.INFO),
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+)
+logger = logging.getLogger(__name__)
+
+# Redis configuration
+REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379")
+TRANSCRIPT_CHANNEL = "transcripts"
+TTS_CHANNEL = "tts_transcripts"
+CALL_END_CHANNEL = "call_end"
+
+# API configuration
+API_BASE = os.getenv("API_BASE_URL", "http://localhost:3000")
+API_INTERNAL_TOKEN = os.getenv("API_INTERNAL_TOKEN")
+
+# Timeouts
+TIMEOUT_RAG_INDEXING = 5.0
+TIMEOUT_CALL_END = 5.0
+
+
+def _get_auth_headers() -> dict:
+    """Get authentication headers for internal API calls."""
+    headers = {"Content-Type": "application/json"}
+    if API_INTERNAL_TOKEN:
+        headers["Authorization"] = f"Bearer {API_INTERNAL_TOKEN}"
+    return headers
+
+
+async def save_transcript_to_redis(redis_client, call_id: str, speaker: str, text: str, timestamp: str):
+    """Save transcript entry to Redis."""
+    try:
+        transcript_entry = {
+            "speaker": speaker,
+            "text": text,
+            "timestamp": timestamp,
+        }
+        redis_key = f"call:{call_id}:transcripts"
+        pipe = redis_client.pipeline()
+        pipe.rpush(redis_key, json.dumps(transcript_entry, ensure_ascii=False))
+        pipe.expire(redis_key, 3600 * 24)  # 24 hours
+        await pipe.execute()
+        logger.debug(f"Saved to Redis: {call_id} - {speaker} - {text}")
+    except Exception as e:
+        logger.error(f"Failed to save transcript to Redis: {e}")
+
+
+async def trigger_rag_indexing(call_id: str, ward_id: str):
+    """Trigger RAG indexing after session ends."""
+    try:
+        async with httpx.AsyncClient() as client:
+            await client.post(
+                f"{API_BASE}/v1/rag/index",
+                json={
+                    "callId": call_id,
+                    "wardId": ward_id,
+                },
+                headers=_get_auth_headers(),
+                timeout=TIMEOUT_RAG_INDEXING,
+            )
+            logger.info(f"RAG indexing triggered: call={call_id}")
+    except Exception as e:
+        logger.error(f"RAG indexing trigger failed: {e}")
+
+
+async def trigger_call_end(call_id: str):
+    """Inform API that the call ended so it can finalize state and summaries."""
+    try:
+        async with httpx.AsyncClient() as client:
+            await client.post(
+                f"{API_BASE}/v1/calls/end",
+                json={"callId": call_id},
+                headers=_get_auth_headers(),
+                timeout=TIMEOUT_CALL_END,
+            )
+            logger.info(f"Call end notified: call={call_id}")
+    except Exception as e:
+        logger.error(f"Call end trigger failed: {e}")
+
+
+async def handle_transcript_message(redis_client, message: dict):
+    """Handle incoming transcript message (STT)."""
+    try:
+        data = json.loads(message["data"])
+        call_id = data.get("call_id")
+        speaker = data.get("speaker")
+        text = data.get("text")
+        timestamp = data.get("timestamp", datetime.utcnow().isoformat())
+
+        if not call_id or not speaker or not text:
+            logger.warning(f"Invalid transcript message: {data}")
+            return
+
+        await save_transcript_to_redis(redis_client, call_id, speaker, text, timestamp)
+    except json.JSONDecodeError as e:
+        logger.error(f"Failed to decode transcript message: {e}")
+    except Exception as e:
+        logger.error(f"Error handling transcript message: {e}")
+
+
+async def handle_tts_message(redis_client, message: dict):
+    """Handle incoming TTS message (AI responses)."""
+    try:
+        data = json.loads(message["data"])
+        call_id = data.get("call_id")
+        text = data.get("text")
+        timestamp = data.get("timestamp", datetime.utcnow().isoformat())
+
+        if not call_id or not text:
+            logger.warning(f"Invalid TTS message: {data}")
+            return
+
+        # TTS messages are always from the AI assistant
+        await save_transcript_to_redis(redis_client, call_id, "assistant", text, timestamp)
+    except json.JSONDecodeError as e:
+        logger.error(f"Failed to decode TTS message: {e}")
+    except Exception as e:
+        logger.error(f"Error handling TTS message: {e}")
+
+
+async def handle_call_end_message(message: dict):
+    """Handle call end notification."""
+    try:
+        data = json.loads(message["data"])
+        call_id = data.get("call_id")
+        ward_id = data.get("ward_id")
+
+        if not call_id or not ward_id:
+            logger.warning(f"Invalid call_end message: {data}")
+            return
+
+        logger.info(f"Call ended: {call_id}, triggering post-processing")
+
+        # Run post-processing tasks
+        tasks = [
+            trigger_call_end(call_id),
+            trigger_rag_indexing(call_id, ward_id),
+        ]
+
+        await asyncio.gather(*tasks, return_exceptions=True)
+        logger.info(f"Post-processing completed for call: {call_id}")
+    except json.JSONDecodeError as e:
+        logger.error(f"Failed to decode call_end message: {e}")
+    except Exception as e:
+        logger.error(f"Error handling call_end message: {e}")
+
+
+async def main():
+    """Main service loop."""
+    logger.info("Starting Transcript Storage Service...")
+    logger.info(f"Connecting to Redis: {REDIS_URL}")
+
+    # Connect to Redis
+    redis_client = None
+    pubsub = None
+
+    try:
+        redis_client = redis_async.from_url(REDIS_URL, decode_responses=True)
+        await redis_client.ping()
+        logger.info("Successfully connected to Redis")
+
+        # Subscribe to channels
+        pubsub = redis_client.pubsub()
+        await pubsub.subscribe(TRANSCRIPT_CHANNEL, TTS_CHANNEL, CALL_END_CHANNEL)
+        logger.info(f"Subscribed to channels: {TRANSCRIPT_CHANNEL}, {TTS_CHANNEL}, {CALL_END_CHANNEL}")
+
+        # Listen for messages
+        async for message in pubsub.listen():
+            if message["type"] != "message":
+                continue
+
+            channel = message["channel"]
+
+            if channel == TRANSCRIPT_CHANNEL:
+                await handle_transcript_message(redis_client, message)
+            elif channel == TTS_CHANNEL:
+                await handle_tts_message(redis_client, message)
+            elif channel == CALL_END_CHANNEL:
+                await handle_call_end_message(message)
+
+    except KeyboardInterrupt:
+        logger.info("Service stopped by user")
+    except Exception as e:
+        logger.error(f"Fatal error: {e}")
+        sys.exit(1)
+    finally:
+        # Cleanup
+        if pubsub:
+            await pubsub.unsubscribe(TRANSCRIPT_CHANNEL, TTS_CHANNEL, CALL_END_CHANNEL)
+            await pubsub.close()
+        if redis_client:
+            await redis_client.close()
+        logger.info("Service shutdown complete")
+
+
+if __name__ == "__main__":
+    print("=" * 50)
+    print("TRANSCRIPT STORAGE SERVICE")
+    print("=" * 50)
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        logger.info("Service stopped by user")
+        sys.exit(0)
+    except Exception as e:
+        logger.error(f"Fatal error: {e}")
+        sys.exit(1)


### PR DESCRIPTION
✨ 작업 개요
기존 simple_agent.py에 집중되어 있던 대화 저장 및 후처리 로직을 별도의 서비스(transcript-storage)로 분리했습니다. 이를 통해 에이전트의 부하를 줄이고, 데이터 흐름을 이벤트 기반으로 개선하여 시스템의 확장성과 유지보수성을 높였습니다.

📋 주요 변경 사항
1. Voice Agent (simple_agent.py) 리팩터링
책임 분리: 직접적인 API 호출(HTTP POST) 및 Redis List 적재 로직을 제거했습니다.

이벤트 발행(Publish): 대화(Transcript) 및 통화 종료(Call End) 이벤트를 Redis 채널로 발행하는 '발행 전용' 클라이언트로 전환했습니다.

안정성 강화: Redis 연결 초기화 로직(init_redis_client)을 개선하여 재시도 및 추적 로그를 보강했습니다.

2. 신규 서비스 구축 (transcript_storage_service.py)
구독(Subscribe): Redis의 transcripts, tts_transcripts, call_end 채널을 실시간 구독합니다.

저장 로직 전담: 수신된 이벤트를 바탕으로 call:{call_id}:transcripts 리스트를 유지하고, 음성 합성(TTS) 메시지를 기록합니다.

후처리 자동화: 통화 종료 이벤트 수신 시 RAG 인덱싱 및 백엔드 통지(API 호출)를 독립적으로 수행합니다.

3. 인프라 및 컨테이너 설정 업데이트
docker-compose.dev.yml: 신규 transcript-storage 서비스 설정을 추가하여 에이전트와 함께 유기적으로 기동되도록 구성했습니다.

환경 변수: 두 서비스가 동일한 agent.env 설정을 공유하여 일관된 Redis 및 API 엔드포인트를 참조합니다.

🏗 데이터 흐름 (Architecture)
Voice Agent: 발화 감지/생성 시 Redis 채널로 Publish.

Redis: 메시지를 실시간으로 브로드캐스팅.

Storage Service: 메시지 Subscribe 후 Redis List 저장 및 API 호출(종료 시).

🔗 관련 이슈
Closes #6 