### PR TITLE
[Feature] 에이전트 초기 발화 지연 최적화 및 RAG 프리로드 시스템 구축 (#14)

### DIFF
--- a/agent/agent.py
+++ b/agent/agent.py
@@ -176,6 +176,25 @@ async def entrypoint(ctx: JobContext):
 
     logger.info(f"Session info: ward_id={ward_id}, call_id={call_id}, direction={call_direction}")
 
+    # 🚀 START PRELOAD IMMEDIATELY - Parallel with WebRTC handshake
+    # This loads weekly vectors from PGVector → Redis cache BEFORE agent joins
+    # By the time first greeting happens, cache is ready (fast searches)
+    if ward_id:
+        logger.info(f"🚀 Starting weekly context preload in background for ward: {ward_id}")
+        rag_client = get_shared_rag_client()
+        # Convert CallDirection enum to string for API
+        direction_str = "outbound" if call_direction == CallDirection.OUTBOUND else "inbound"
+        asyncio.create_task(rag_client.preload_weekly_context(ward_id, direction_str))
+
+    # Wait for user participant to join
+    logger.info("Waiting for user participant to join...")
+    user_participant_identity = await wait_for_participant(ctx, timeout=30.0)
+
+    if user_participant_identity:
+        logger.info(f"✅ User participant joined: {user_participant_identity}")
+    else:
+        logger.warning("⚠️  User participant did not join within timeout")
+
     # Load conversation context in background with timeout
     # IMPORTANT: Don't block session start - RAG is optional enhancement
     # If RAG is slow/unavailable, agent still starts and greets user

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -69,6 +69,24 @@ logger = logging.getLogger(__name__)
 server = AgentServer()
 
 
+def _create_task_logged(coro, name: str):
+    """
+    Create a background task and log exceptions to avoid silent failures.
+    """
+    task = asyncio.create_task(coro, name=name)
+
+    def _log_error(t: asyncio.Task):
+        try:
+            exc = t.exception()
+            if exc:
+                logger.error(f"Background task '{name}' failed: {exc}", exc_info=True)
+        except asyncio.CancelledError:
+            pass
+
+    task.add_done_callback(_log_error)
+    return task
+
+
 def prewarm(proc: JobProcess):
     """Prewarm function - loads models shared across sessions."""
     try:
@@ -184,7 +202,10 @@ async def entrypoint(ctx: JobContext):
         rag_client = get_shared_rag_client()
         # Convert CallDirection enum to string for API
         direction_str = "outbound" if call_direction == CallDirection.OUTBOUND else "inbound"
-        asyncio.create_task(rag_client.preload_weekly_context(ward_id, direction_str))
+        _create_task_logged(
+            rag_client.preload_weekly_context(ward_id, direction_str),
+            name="preload_weekly_context",
+        )
 
     # Wait for user participant to join
     logger.info("Waiting for user participant to join...")
@@ -288,7 +309,10 @@ async def entrypoint(ctx: JobContext):
     )
 
     # Start takeover polling in background
-    takeover_task = asyncio.create_task(takeover_handler.start_polling())
+    takeover_task = _create_task_logged(
+        takeover_handler.start_polling(),
+        name="takeover_polling",
+    )
 
     # Start session (this blocks until session ends)
     await session.start(

--- a/agent/constants.py
+++ b/agent/constants.py
@@ -8,6 +8,7 @@ Centralized configuration to prevent duplication and inconsistencies.
 TRANSCRIPT_CHANNEL = "transcripts"
 TTS_CHANNEL = "tts_transcripts"
 CALL_END_CHANNEL = "call_end"
+GREETING_CHANNEL_PREFIX = "greeting:ward:"  # Channel: greeting:ward:{wardId}
 
 # Timeouts (seconds)
 TIMEOUT_CALL_CONTEXT = 10.0       # RAG context/search default for PGVector queries
@@ -15,6 +16,7 @@ TIMEOUT_RAG_INDEXING = 10.0       # RAG indexing trigger (embedding generation)
 TIMEOUT_CALL_END = 10.0           # Call end notification (AI analysis)
 TIMEOUT_RAG_CONTEXT_WARMUP = 2.0  # Fast context fetch during call startup
 TIMEOUT_RAG_SEARCH_QUICK = 3.0    # Quick RAG search during conversation
+TIMEOUT_GREETING_FETCH = 0.5      # Quick Redis fetch for preloaded greeting (300-500ms)
 
 # Redis retry configuration
 REDIS_MAX_RETRIES = 5

--- a/agent/personality/elderly_companion.py
+++ b/agent/personality/elderly_companion.py
@@ -47,8 +47,6 @@ class ElderlyCompanionAgent(Agent):
             instructions=self._build_instructions(ward_context, call_direction),
         )
 
-
-
     async def on_enter(self) -> None:
         """
         Called when agent enters the session - uses Push-based greeting approach.
@@ -75,7 +73,7 @@ class ElderlyCompanionAgent(Agent):
             fallback_greeting = GREETING_INBOUND
 
         # 🚀 STEP 1: Immediately say static greeting (zero latency)
-        logger.info(f"💬 Saying static greeting immediately (direction={self.call_direction})")
+        logger.info(f"[greeting] Saying static greeting immediately (direction={self.call_direction})")
         self.session.say(fallback_greeting, allow_interruptions=False)
 
         # 📡 STEP 2: Subscribe to greeting channel (non-blocking, Push-based)
@@ -103,7 +101,7 @@ class ElderlyCompanionAgent(Agent):
             personalized_greeting: Full greeting text from backend RAG service
         """
         try:
-            logger.info(f"🎯 Greeting received via Pub/Sub (length={len(personalized_greeting)})")
+            logger.info(f"[greeting] Received via Pub/Sub (length={len(personalized_greeting)})")
 
             # Determine what static greeting was already said
             if self.call_direction == CallDirection.OUTBOUND:
@@ -113,21 +111,21 @@ class ElderlyCompanionAgent(Agent):
 
             # Skip if it's identical to what we already said (after normalization)
             if self._normalize_greeting(personalized_greeting) == self._normalize_greeting(static_greeting):
-                logger.info("⚠️  Personalized greeting same as static, skipping")
+                logger.info("[greeting] Personalized greeting same as static, skipping")
                 return
 
             # Extract additional content (remove static prefix if present)
             additional_content = self._extract_additional_content(personalized_greeting, static_greeting)
 
             if additional_content:
-                logger.info(f"✨ Adding personalized content: {additional_content[:50]}...")
+                logger.info(f"[greeting] Adding personalized content: {additional_content[:50]}...")
                 # Say the additional personalized content
                 self.session.say(additional_content, allow_interruptions=True)
             else:
-                logger.info("📋 No additional content to add")
+                logger.info("[greeting] No additional content to add")
 
         except Exception as e:
-            logger.error(f"❌ Error processing received greeting: {e}", exc_info=True)
+            logger.error(f"[greeting] Error processing received greeting: {e}", exc_info=True)
 
     def _extract_additional_content(self, full_greeting: str, static_part: str) -> Optional[str]:
         """
@@ -156,8 +154,8 @@ class ElderlyCompanionAgent(Agent):
                     return additional
 
         # Strategy 2: Split by sentence and remove first if it's static greeting
-        # Handle various sentence endings: '. ', '。', '. '
-        for delimiter in ['. ', '。 ', '. ', '.\n']:
+        # Handle various sentence endings including Korean punctuation
+        for delimiter in ['. ', '。 ', '. ', '.\n', '! ', '? ', '！ ', '？ ']:
             if delimiter in full_greeting:
                 sentences = full_greeting.split(delimiter, 1)
                 if len(sentences) >= 2:
@@ -181,11 +179,11 @@ class ElderlyCompanionAgent(Agent):
 
         - Trim whitespace
         - Lowercase
-        - Remove trailing common punctuation
+        - Remove trailing common punctuation (., !, ?, ，, ？, ！, …)
         - Collapse double spaces
         """
         normalized = text.strip().lower()
-        while normalized.endswith(('.', '!', '?')):
+        while normalized.endswith(('.', '!', '?', '，', '？', '！', '…')):
             normalized = normalized[:-1].strip()
         normalized = " ".join(normalized.split())
         return normalized

--- a/agent/personality/elderly_companion.py
+++ b/agent/personality/elderly_companion.py
@@ -7,7 +7,7 @@ from typing import Annotated, Optional
 from livekit.agents import Agent, RunContext, function_tool
 from pydantic import Field
 
-from constants import TIMEOUT_RAG_SEARCH_QUICK
+from constants import TIMEOUT_RAG_SEARCH_QUICK, TIMEOUT_GREETING_FETCH
 from rag_client import get_shared_rag_client
 from services.redis_pubsub import subscribe_to_greeting
 from userdata import SessionUserdata
@@ -83,7 +83,11 @@ class ElderlyCompanionAgent(Agent):
             ward_id = self.session.userdata.ward_id
             # Launch background task to subscribe and wait for greeting
             asyncio.create_task(
-                subscribe_to_greeting(ward_id, self._on_greeting_received)
+                subscribe_to_greeting(
+                  ward_id,
+                  self._on_greeting_received,
+                  timeout=TIMEOUT_GREETING_FETCH,
+                )
             )
         else:
             logger.warning("Ward ID not available, skipping personalized greeting subscription")
@@ -107,8 +111,8 @@ class ElderlyCompanionAgent(Agent):
             else:
                 static_greeting = GREETING_INBOUND
 
-            # Skip if it's identical to what we already said
-            if personalized_greeting.strip() == static_greeting.strip():
+            # Skip if it's identical to what we already said (after normalization)
+            if self._normalize_greeting(personalized_greeting) == self._normalize_greeting(static_greeting):
                 logger.info("⚠️  Personalized greeting same as static, skipping")
                 return
 
@@ -141,8 +145,8 @@ class ElderlyCompanionAgent(Agent):
         Returns:
             Additional content to say, or None if nothing to add
         """
-        full_greeting = full_greeting.strip()
-        static_part = static_part.strip()
+        full_greeting = self._normalize_greeting(full_greeting)
+        static_part = self._normalize_greeting(static_part)
 
         # Strategy 1: Remove exact static prefix
         if full_greeting.startswith(static_part):
@@ -169,6 +173,21 @@ class ElderlyCompanionAgent(Agent):
             return full_greeting
 
         return None
+
+    def _normalize_greeting(self, text: str) -> str:
+        """
+        Normalize greeting strings for safer comparison.
+
+        - Trim whitespace
+        - Lowercase
+        - Remove trailing common punctuation
+        - Collapse double spaces
+        """
+        normalized = text.strip().lower()
+        while normalized.endswith(('.', '!', '?')):
+            normalized = normalized[:-1].strip()
+        normalized = " ".join(normalized.split())
+        return normalized
 
     def _build_instructions(self, ward_context: str = "", call_direction: str = "inbound") -> str:
         """Build agent instructions with optional context."""

--- a/agent/personality/elderly_companion.py
+++ b/agent/personality/elderly_companion.py
@@ -152,7 +152,8 @@ class ElderlyCompanionAgent(Agent):
         if full_greeting.startswith(static_part):
             additional = full_greeting[len(static_part):].strip()
             if additional and len(additional) > 5:  # Meaningful content
-                return additional
+                if self._normalize_greeting(additional) != static_part:
+                    return additional
 
         # Strategy 2: Split by sentence and remove first if it's static greeting
         # Handle various sentence endings: '. ', '。', '. '
@@ -165,7 +166,7 @@ class ElderlyCompanionAgent(Agent):
 
                     # If first sentence matches static greeting, use rest
                     if first_sentence == static_part or first_sentence + '.' == static_part:
-                        if rest and len(rest) > 5:
+                        if rest and len(rest) > 5 and self._normalize_greeting(rest) != static_part:
                             return rest
 
         # Strategy 3: If full greeting is completely different, use it

--- a/agent/personality/elderly_companion.py
+++ b/agent/personality/elderly_companion.py
@@ -1,13 +1,15 @@
 """Elderly Companion Agent - 어르신 돌봄 AI 에이전트."""
+import asyncio
 import logging
 from enum import Enum
-from typing import Annotated
+from typing import Annotated, Optional
 
 from livekit.agents import Agent, RunContext, function_tool
 from pydantic import Field
 
 from constants import TIMEOUT_RAG_SEARCH_QUICK
 from rag_client import get_shared_rag_client
+from services.redis_pubsub import subscribe_to_greeting
 from userdata import SessionUserdata
 
 logger = logging.getLogger(__name__)
@@ -45,8 +47,20 @@ class ElderlyCompanionAgent(Agent):
             instructions=self._build_instructions(ward_context, call_direction),
         )
 
+
+
     async def on_enter(self) -> None:
-        """Called when agent enters the session - greets based on call direction."""
+        """
+        Called when agent enters the session - uses Push-based greeting approach.
+
+        Push-based greeting strategy:
+        1. Immediately say static greeting ("안녕하세요, 어르신" or "여보세요. 소담입니다")
+        2. Subscribe to Redis Pub/Sub channel: greeting:ward:{wardId}
+        3. When backend publishes personalized greeting, receive and say it
+
+        This ensures zero-latency first response while receiving RAG-enhanced greeting
+        when the backend is ready.
+        """
         logger.info(f"ElderlyCompanionAgent entering with direction={self.call_direction}")
 
         # Check if session is initialized
@@ -54,13 +68,107 @@ class ElderlyCompanionAgent(Agent):
             logger.error("Session not initialized in on_enter")
             return
 
-        # Use different greetings based on call direction
+        # Determine static greeting based on call direction
         if self.call_direction == CallDirection.OUTBOUND:
-            greeting = GREETING_OUTBOUND
+            fallback_greeting = GREETING_OUTBOUND
         else:
-            greeting = GREETING_INBOUND
+            fallback_greeting = GREETING_INBOUND
 
-        self.session.say(greeting, allow_interruptions=False)
+        # 🚀 STEP 1: Immediately say static greeting (zero latency)
+        logger.info(f"💬 Saying static greeting immediately (direction={self.call_direction})")
+        self.session.say(fallback_greeting, allow_interruptions=False)
+
+        # 📡 STEP 2: Subscribe to greeting channel (non-blocking, Push-based)
+        if hasattr(self.session, 'userdata') and hasattr(self.session.userdata, 'ward_id'):
+            ward_id = self.session.userdata.ward_id
+            # Launch background task to subscribe and wait for greeting
+            asyncio.create_task(
+                subscribe_to_greeting(ward_id, self._on_greeting_received)
+            )
+        else:
+            logger.warning("Ward ID not available, skipping personalized greeting subscription")
+
+    async def _on_greeting_received(self, personalized_greeting: str) -> None:
+        """
+        Callback invoked when personalized greeting is received via Redis Pub/Sub.
+
+        This is called by the subscription when the backend publishes a greeting
+        to the channel: greeting:ward:{wardId}
+
+        Args:
+            personalized_greeting: Full greeting text from backend RAG service
+        """
+        try:
+            logger.info(f"🎯 Greeting received via Pub/Sub (length={len(personalized_greeting)})")
+
+            # Determine what static greeting was already said
+            if self.call_direction == CallDirection.OUTBOUND:
+                static_greeting = GREETING_OUTBOUND
+            else:
+                static_greeting = GREETING_INBOUND
+
+            # Skip if it's identical to what we already said
+            if personalized_greeting.strip() == static_greeting.strip():
+                logger.info("⚠️  Personalized greeting same as static, skipping")
+                return
+
+            # Extract additional content (remove static prefix if present)
+            additional_content = self._extract_additional_content(personalized_greeting, static_greeting)
+
+            if additional_content:
+                logger.info(f"✨ Adding personalized content: {additional_content[:50]}...")
+                # Say the additional personalized content
+                self.session.say(additional_content, allow_interruptions=True)
+            else:
+                logger.info("📋 No additional content to add")
+
+        except Exception as e:
+            logger.error(f"❌ Error processing received greeting: {e}", exc_info=True)
+
+    def _extract_additional_content(self, full_greeting: str, static_part: str) -> Optional[str]:
+        """
+        Extract additional personalized content from full greeting.
+
+        Tries multiple strategies:
+        1. Remove exact static prefix
+        2. Remove first sentence if it matches static greeting
+        3. Return entire greeting if different from static
+
+        Args:
+            full_greeting: Complete greeting from RAG
+            static_part: Static greeting prefix to remove
+
+        Returns:
+            Additional content to say, or None if nothing to add
+        """
+        full_greeting = full_greeting.strip()
+        static_part = static_part.strip()
+
+        # Strategy 1: Remove exact static prefix
+        if full_greeting.startswith(static_part):
+            additional = full_greeting[len(static_part):].strip()
+            if additional and len(additional) > 5:  # Meaningful content
+                return additional
+
+        # Strategy 2: Split by sentence and remove first if it's static greeting
+        # Handle various sentence endings: '. ', '。', '. '
+        for delimiter in ['. ', '。 ', '. ', '.\n']:
+            if delimiter in full_greeting:
+                sentences = full_greeting.split(delimiter, 1)
+                if len(sentences) >= 2:
+                    first_sentence = sentences[0].strip()
+                    rest = sentences[1].strip()
+
+                    # If first sentence matches static greeting, use rest
+                    if first_sentence == static_part or first_sentence + '.' == static_part:
+                        if rest and len(rest) > 5:
+                            return rest
+
+        # Strategy 3: If full greeting is completely different, use it
+        if full_greeting != static_part and len(full_greeting) > len(static_part) + 10:
+            return full_greeting
+
+        return None
 
     def _build_instructions(self, ward_context: str = "", call_direction: str = "inbound") -> str:
         """Build agent instructions with optional context."""

--- a/agent/rag_client.py
+++ b/agent/rag_client.py
@@ -189,6 +189,48 @@ class RagClient:
             logger.error(f"Unexpected error getting context: {e}", exc_info=True)
             return []
 
+    async def preload_weekly_context(
+        self,
+        ward_id: str,
+        call_direction: str = "inbound",
+    ) -> bool:
+        """
+        Preload weekly context into Redis cache before call starts
+
+        This should be called when participants join the room (before first greeting)
+        to ensure fast RAG searches during the conversation.
+
+        Args:
+            ward_id: Ward UUID
+            call_direction: Call direction ("inbound" or "outbound")
+
+        Returns:
+            True if preload started successfully, False otherwise
+        """
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(
+                    f"{self.api_base}/v1/rag/preload",
+                    json={"wardId": ward_id, "callDirection": call_direction},
+                    headers=self._get_headers(),
+                    timeout=self.timeout,
+                )
+                response.raise_for_status()
+                logger.info(f"✅ Weekly context preload started for ward={ward_id}, direction={call_direction}")
+                return True
+        except httpx.TimeoutException:
+            logger.warning(f"⚠️  Preload timed out after {self.timeout}s for ward={ward_id}")
+            return False
+        except httpx.HTTPStatusError as e:
+            logger.error(f"❌ Preload HTTP error {e.response.status_code}: {e}")
+            return False
+        except httpx.HTTPError as e:
+            logger.error(f"❌ Preload network error: {e}")
+            return False
+        except Exception as e:
+            logger.error(f"❌ Unexpected error during preload: {e}", exc_info=True)
+            return False
+
     async def build_context_prompt(
         self,
         ward_id: str,

--- a/agent/services/redis_pubsub.py
+++ b/agent/services/redis_pubsub.py
@@ -198,7 +198,9 @@ async def subscribe_to_greeting(
         # Clean up subscription
         try:
             await pubsub.unsubscribe(channel_name)
-            await pubsub.close()
-            logger.debug(f"Unsubscribed from greeting channel: {channel_name}")
-        except Exception as e:
-            logger.error(f"Error closing pubsub connection: {e}")
+        finally:
+            try:
+                await pubsub.close()
+                logger.debug(f"Unsubscribed/closed greeting channel: {channel_name}")
+            except Exception as e:
+                logger.error(f"Error closing pubsub connection: {e}")

--- a/agent/services/redis_pubsub.py
+++ b/agent/services/redis_pubsub.py
@@ -12,6 +12,7 @@ from config import validate_env_vars
 from constants import (
     TRANSCRIPT_CHANNEL,
     CALL_END_CHANNEL,
+    GREETING_CHANNEL_PREFIX,
     REDIS_MAX_RETRIES,
     REDIS_RETRY_DELAY,
     REDIS_RETRY_BACKOFF,
@@ -128,3 +129,66 @@ async def publish_call_end(call_id: str, ward_id: str) -> bool:
     except Exception as e:
         logger.error(f"Failed to publish call_end to Redis: {e}")
         return False
+
+
+async def subscribe_to_greeting(ward_id: str, callback, timeout: float = 5.0) -> None:
+    """
+    Subscribe to greeting channel and invoke callback when greeting arrives.
+    
+    This implements a Push-based approach where the agent subscribes to a Redis
+    channel and receives the personalized greeting when the backend publishes it.
+    
+    Channel: greeting:ward:{wardId}
+    
+    Args:
+        ward_id: Ward UUID
+        callback: Async function to call with greeting text when received
+        timeout: Maximum time to wait for greeting (default: 5 seconds)
+    
+    Flow:
+        1. Subscribe to greeting:ward:{wardId}
+        2. Wait for message (with timeout)
+        3. When message arrives, invoke callback with greeting text
+        4. Auto-unsubscribe after first message or timeout
+    """
+    client = await get_redis_client()
+    if not client:
+        logger.warning(f"Redis client unavailable for greeting subscription (ward={ward_id})")
+        return
+
+    channel_name = f"{GREETING_CHANNEL_PREFIX}{ward_id}"
+    pubsub = client.pubsub()
+    
+    try:
+        # Subscribe to the greeting channel
+        await pubsub.subscribe(channel_name)
+        logger.info(f"📡 Subscribed to greeting channel: {channel_name}")
+        
+        # Wait for greeting message with timeout
+        try:
+            async with asyncio.timeout(timeout):
+                async for message in pubsub.listen():
+                    if message["type"] == "message":
+                        greeting_text = message["data"]
+                        logger.info(f"✅ Received greeting from channel (ward={ward_id}, length={len(greeting_text)})")
+                        
+                        # Invoke callback with greeting
+                        await callback(greeting_text)
+                        
+                        # Unsubscribe after receiving first message
+                        break
+        except asyncio.TimeoutError:
+            logger.info(f"⏱️  Greeting subscription timed out after {timeout}s (ward={ward_id})")
+    
+    except Exception as e:
+        logger.error(f"❌ Error in greeting subscription (ward={ward_id}): {e}")
+    
+    finally:
+        # Clean up subscription
+        try:
+            await pubsub.unsubscribe(channel_name)
+            await pubsub.close()
+            logger.debug(f"Unsubscribed from greeting channel: {channel_name}")
+        except Exception as e:
+            logger.error(f"Error closing pubsub connection: {e}")
+

--- a/agent/services/redis_pubsub.py
+++ b/agent/services/redis_pubsub.py
@@ -13,6 +13,7 @@ from constants import (
     TRANSCRIPT_CHANNEL,
     CALL_END_CHANNEL,
     GREETING_CHANNEL_PREFIX,
+    TIMEOUT_GREETING_FETCH,
     REDIS_MAX_RETRIES,
     REDIS_RETRY_DELAY,
     REDIS_RETRY_BACKOFF,
@@ -131,7 +132,11 @@ async def publish_call_end(call_id: str, ward_id: str) -> bool:
         return False
 
 
-async def subscribe_to_greeting(ward_id: str, callback, timeout: float = 5.0) -> None:
+async def subscribe_to_greeting(
+    ward_id: str,
+    callback,
+    timeout: float = TIMEOUT_GREETING_FETCH,
+) -> None:
     """
     Subscribe to greeting channel and invoke callback when greeting arrives.
     
@@ -169,7 +174,13 @@ async def subscribe_to_greeting(ward_id: str, callback, timeout: float = 5.0) ->
             async with asyncio.timeout(timeout):
                 async for message in pubsub.listen():
                     if message["type"] == "message":
-                        greeting_text = message["data"]
+                        raw_data = message["data"]
+                        # Redis can return bytes; normalize to str for TTS
+                        if isinstance(raw_data, bytes):
+                            greeting_text = raw_data.decode("utf-8", errors="ignore")
+                        else:
+                            greeting_text = str(raw_data)
+
                         logger.info(f"✅ Received greeting from channel (ward={ward_id}, length={len(greeting_text)})")
                         
                         # Invoke callback with greeting
@@ -191,4 +202,3 @@ async def subscribe_to_greeting(ward_id: str, callback, timeout: float = 5.0) ->
             logger.debug(f"Unsubscribed from greeting channel: {channel_name}")
         except Exception as e:
             logger.error(f"Error closing pubsub connection: {e}")
-

--- a/agent/services/redis_pubsub.py
+++ b/agent/services/redis_pubsub.py
@@ -167,7 +167,7 @@ async def subscribe_to_greeting(
     try:
         # Subscribe to the greeting channel
         await pubsub.subscribe(channel_name)
-        logger.info(f"📡 Subscribed to greeting channel: {channel_name}")
+        logger.info(f"[greeting] Subscribed to greeting channel: {channel_name}")
         
         # Wait for greeting message with timeout
         try:
@@ -181,7 +181,7 @@ async def subscribe_to_greeting(
                         else:
                             greeting_text = str(raw_data)
 
-                        logger.info(f"✅ Received greeting from channel (ward={ward_id}, length={len(greeting_text)})")
+                        logger.info(f"[greeting] Received greeting from channel (ward={ward_id}, length={len(greeting_text)})")
                         
                         # Invoke callback with greeting
                         await callback(greeting_text)
@@ -189,10 +189,10 @@ async def subscribe_to_greeting(
                         # Unsubscribe after receiving first message
                         break
         except asyncio.TimeoutError:
-            logger.info(f"⏱️  Greeting subscription timed out after {timeout}s (ward={ward_id})")
+            logger.info(f"[greeting] Subscription timed out after {timeout}s (ward={ward_id})")
     
     except Exception as e:
-        logger.error(f"❌ Error in greeting subscription (ward={ward_id}): {e}")
+        logger.error(f"[greeting] Error in greeting subscription (ward={ward_id}): {e}")
     
     finally:
         # Clean up subscription


### PR DESCRIPTION
✨ 작업 개요
통화 시작 시 개인화된 인사말을 생성하기 위해 발생하던 에이전트의 침묵 시간을 제거했습니다. "정적 인사말 즉시 발화 후 개인화 문구 추가" 전략과 **"WebRTC-RAG 병렬 프리로드"**를 통해 연결 직후 에이전트가 즉각적으로 반응하면서도 고도화된 개인화 대화를 제공할 수 있도록 개선했습니다.

📋 주요 변경 사항
1. UX 및 발화 로직 최적화 (Greeting Pipeline)
"선 발화 후 보완" 전략: on_enter 시점에 고정된 인사말을 즉시 내뱉고, 백그라운드에서 Redis Pub/Sub을 통해 수신된 개인화 문구를 자연스럽게 이어 붙입니다.

중복 발화 방지: _normalize_greeting 헬퍼를 통해 공백, 문장부호 등을 제거하고 정적/개인화 문구를 비교함으로써 "안녕하세요, 안녕하세요"와 같은 어색한 반복을 차단합니다.

문장 연결 최적화: _extract_additional_content 로직으로 개인화 인사말 중 이미 말한 내용을 제외한 "새로운 정보"만 추출해 발화합니다.

2. RAG 프리로드 및 성능 향상 (Warm-up)
병렬 처리: WebRTC 핸드셰이크가 진행되는 동안 백그라운드 태스크로 preload_weekly_context를 실행하여 Redis 캐시를 미리 확보합니다.

콜 시작 지연 최소화: 에이전트가 실제 대화에 진입하기 전 이미 RAG 컨텍스트가 준비되어 있어, 첫 응답의 품질과 속도가 비약적으로 향상되었습니다.

3. 시스템 안정성 및 코드 품질 (Infrastructure)
Redis Pub/Sub 고도화: subscribe_to_greeting 함수를 통해 Push 방식의 인사말 수신 구조를 확립하고, 단회성 구독 후 자동 클린업을 보장합니다.

데이터 정규화: 수신된 바이너리(Bytes) 데이터를 UTF-8로 디코딩하고 문자열로 강제 변환하여 TTS 엔진의 타입 오류를 방지했습니다.

상수 중앙화: TIMEOUT_GREETING_FETCH 등 하드코딩된 타임아웃 값을 constants.py로 모아 관리 효율성을 높였습니다.

🏗 데이터 흐름 및 발화 전략
세션 시작: WebRTC 연결 시도 + RAG 주간 데이터 프리로드 (병렬 실행).

즉시 발화: 연결 성공 즉시 기본 인사말("안녕하세요, 어르신!") 발화.

데이터 수신: Redis Pub/Sub 채널(greeting:ward:{id})을 통해 생성된 개인화 인사말 도착.

추가 발화: 기존 인사말과 중복되지 않는 새로운 내용("어제 잠은 잘 주무셨나요?")만 골라 추가 발화.

🔗 관련 이슈
Closes #14 