### PR TITLE
fix(transcript): timestamp 1970년 표시 버그 수정

### DIFF
--- a/agent/handlers/transcript.py
+++ b/agent/handlers/transcript.py
@@ -2,6 +2,7 @@
 import asyncio
 import json
 import logging
+import time
 from typing import Set, Callable
 
 from services.redis_pubsub import publish_transcript, store_transcript_direct
@@ -37,7 +38,7 @@ class TranscriptHandler:
                 "type": "transcript",
                 "role": role,
                 "text": text,
-                "timestamp": int(asyncio.get_event_loop().time() * 1000)
+                "timestamp": int(time.time() * 1000)
             })
             await self.room.local_participant.publish_data(
                 payload,


### PR DESCRIPTION
## Summary
- 실시간 대화 timestamp가 1970년으로 표시되는 버그 수정
- asyncio.get_event_loop().time()이 이벤트 루프 경과 시간 반환하는 문제
- time.time()으로 변경하여 올바른 Unix timestamp 사용

## Test plan
- [ ] 웹 대시보드에서 실시간 대화 시간이 현재 시간으로 정상 표시 확인

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)