### PR TITLE
[Feature] 에이전트 시간 인지 능력 고도화 및 인사말 수신 안정성 개선 (#17)

### DIFF
--- a/agent/constants.py
+++ b/agent/constants.py
@@ -16,7 +16,7 @@ TIMEOUT_RAG_INDEXING = 10.0       # RAG indexing trigger (embedding generation)
 TIMEOUT_CALL_END = 10.0           # Call end notification (AI analysis)
 TIMEOUT_RAG_CONTEXT_WARMUP = 2.0  # Fast context fetch during call startup
 TIMEOUT_RAG_SEARCH_QUICK = 3.0    # Quick RAG search during conversation
-TIMEOUT_GREETING_FETCH = 0.5      # Quick Redis fetch for preloaded greeting (300-500ms)
+TIMEOUT_GREETING_FETCH = 5.0      # Wait for personalized greeting from Redis Pub/Sub (allows time for LLM generation)
 
 # Redis retry configuration
 REDIS_MAX_RETRIES = 5

--- a/agent/constants.py
+++ b/agent/constants.py
@@ -3,12 +3,17 @@ Shared constants for voice agent services.
 
 Centralized configuration to prevent duplication and inconsistencies.
 """
+import os
 
 # Redis Pub/Sub channel names
 TRANSCRIPT_CHANNEL = "transcripts"
 TTS_CHANNEL = "tts_transcripts"
 CALL_END_CHANNEL = "call_end"
 GREETING_CHANNEL_PREFIX = "greeting:ward:"  # Channel: greeting:ward:{wardId}
+
+# Timezone configuration
+# Use IANA timezone names to support DST and avoid hardcoded offsets.
+AGENT_TIMEZONE = os.getenv("AGENT_TIMEZONE", "Asia/Seoul")
 
 # Timeouts (seconds)
 TIMEOUT_CALL_CONTEXT = 10.0       # RAG context/search default for PGVector queries
@@ -17,6 +22,12 @@ TIMEOUT_CALL_END = 10.0           # Call end notification (AI analysis)
 TIMEOUT_RAG_CONTEXT_WARMUP = 2.0  # Fast context fetch during call startup
 TIMEOUT_RAG_SEARCH_QUICK = 3.0    # Quick RAG search during conversation
 TIMEOUT_GREETING_FETCH = 5.0      # Wait for personalized greeting from Redis Pub/Sub (allows time for LLM generation)
+
+# Similarity threshold for memory recall (lowered from 0.5 to 0.4 to improve recall coverage).
+# Tune via env var if relevance drops: RAG_MEMORY_SIMILARITY_THRESHOLD.
+MEMORY_SIMILARITY_THRESHOLD = float(
+    os.getenv("RAG_MEMORY_SIMILARITY_THRESHOLD", "0.4")
+)
 
 # Redis retry configuration
 REDIS_MAX_RETRIES = 5

--- a/agent/personality/elderly_companion.py
+++ b/agent/personality/elderly_companion.py
@@ -1,15 +1,22 @@
 """Elderly Companion Agent - 어르신 돌봄 AI 에이전트."""
 import asyncio
 import logging
-from datetime import datetime, timedelta
+import time
+from datetime import datetime
 from enum import Enum
 from typing import Annotated, Optional
+from zoneinfo import ZoneInfo
 
 from livekit.agents import Agent, RunContext, function_tool
 from pydantic import Field
 
-from constants import TIMEOUT_RAG_SEARCH_QUICK, TIMEOUT_GREETING_FETCH
-from rag_client import get_shared_rag_client
+from constants import (
+    AGENT_TIMEZONE,
+    MEMORY_SIMILARITY_THRESHOLD,
+    TIMEOUT_GREETING_FETCH,
+    TIMEOUT_RAG_SEARCH_QUICK,
+)
+from rag_client import format_relative_time_ko, get_shared_rag_client
 from services.redis_pubsub import subscribe_to_greeting
 from userdata import SessionUserdata
 
@@ -80,12 +87,29 @@ class ElderlyCompanionAgent(Agent):
         # 📡 STEP 2: Subscribe to greeting channel (non-blocking, Push-based)
         if hasattr(self.session, 'userdata') and hasattr(self.session.userdata, 'ward_id'):
             ward_id = self.session.userdata.ward_id
-            # Launch background task to subscribe and wait for greeting
+            logger.info(
+                f"[greeting] Waiting up to {TIMEOUT_GREETING_FETCH}s for personalized greeting (ward={ward_id})"
+            )
+
+            greeting_received = asyncio.Event()
+            start_time = time.monotonic()
+
+            async def on_greeting_with_timing(personalized_greeting: str) -> None:
+                elapsed = time.monotonic() - start_time
+                logger.info(
+                    f"[greeting] Personalized greeting received after {elapsed:.2f}s (ward={ward_id})"
+                )
+                greeting_received.set()
+                await self._on_greeting_received(personalized_greeting)
+
+            asyncio.create_task(
+                self._log_greeting_timeout(greeting_received, start_time, ward_id)
+            )
             asyncio.create_task(
                 subscribe_to_greeting(
-                  ward_id,
-                  self._on_greeting_received,
-                  timeout=TIMEOUT_GREETING_FETCH,
+                    ward_id,
+                    on_greeting_with_timing,
+                    timeout=TIMEOUT_GREETING_FETCH,
                 )
             )
         else:
@@ -191,11 +215,10 @@ class ElderlyCompanionAgent(Agent):
 
     def _build_instructions(self, ward_context: str = "", call_direction: str = "inbound") -> str:
         """Build agent instructions with optional context and current time."""
-        # Get current KST time (UTC+9)
-        utc_now = datetime.utcnow()
-        kst_now = utc_now + timedelta(hours=9)
-        current_time_kst = kst_now.strftime("%Y년 %m월 %d일 %H시 %M분")
-        current_date_kst = kst_now.strftime("%Y년 %m월 %d일")
+        tz = ZoneInfo(AGENT_TIMEZONE)
+        local_now = datetime.now(tz)
+        current_time_kst = local_now.strftime("%Y년 %m월 %d일 %H시 %M분")
+        current_date_kst = local_now.strftime("%Y년 %m월 %d일")
         
         base = (
             "You are a warm, caring AI companion for elderly Korean users.\n"
@@ -216,14 +239,8 @@ class ElderlyCompanionAgent(Agent):
             "- When the user mentions family, health, past events, or personal topics, "
             "use the search_memory tool to recall previous conversations\n"
             "- Retrieved memories include date labels like '[날짜: 2026-01-12 14:30 KST]'\n"
-            "- Interpret these dates naturally in Korean:\n"
-            "  * Today's conversation: '오늘', '아까', '방금'\n"
-            "  * Yesterday: '어제'\n"
-            "  * 2-6 days ago: 'N일 전' (예: '3일 전')\n"
-            "  * 1 week ago: '지난주'\n"
-            "  * 2+ weeks ago: 'N주 전' (예: '2주 전')\n"
-            "  * 1+ months ago: 'N개월 전' (예: '한 달 전', '두 달 전')\n"
-            "- Use these time references naturally: '어제 말씀하신 손자분...', '지난주에 병원 가셨다고 하셨죠?'\n"
+            "- When available, a relative time hint like '[경과: 3일 전]' is provided; "
+            "use it naturally (e.g., '어제 말씀하신 손자분...', '지난주에 병원 가셨다고 하셨죠?')\n"
             "- Use retrieved memories naturally without explicitly saying '기억을 검색했습니다'\n"
             "- If no relevant memory found, continue conversation naturally\n\n"
         )
@@ -315,10 +332,13 @@ class ElderlyCompanionAgent(Agent):
                 similarity = result.get("similarity", 0)
                 created_at = result.get("createdAt", "")
 
-                # Only include results with reasonable similarity (>0.4)
-                if similarity > 0.4 and text:
-                    # Text already contains [날짜: ...] prefix from backend
-                    context_parts.append(text)
+                # Only include results with reasonable similarity
+                if similarity >= MEMORY_SIMILARITY_THRESHOLD and text:
+                    relative_time = format_relative_time_ko(created_at)
+                    if relative_time:
+                        context_parts.append(f"{text}\n[경과: {relative_time}]")
+                    else:
+                        context_parts.append(text)
 
             if not context_parts:
                 return "관련된 과거 대화가 없습니다."
@@ -329,3 +349,18 @@ class ElderlyCompanionAgent(Agent):
         except Exception as e:
             logger.error(f"RAG search error: {e}")
             return "기억 검색 중 오류가 발생했습니다."
+
+    async def _log_greeting_timeout(
+        self,
+        greeting_received: asyncio.Event,
+        start_time: float,
+        ward_id: str,
+    ) -> None:
+        await asyncio.sleep(TIMEOUT_GREETING_FETCH)
+        if greeting_received.is_set():
+            return
+        elapsed = time.monotonic() - start_time
+        logger.warning(
+            f"[greeting] No personalized greeting within {elapsed:.2f}s (ward={ward_id}); "
+            "using static greeting only"
+        )

--- a/agent/personality/elderly_companion.py
+++ b/agent/personality/elderly_companion.py
@@ -1,6 +1,7 @@
 """Elderly Companion Agent - 어르신 돌봄 AI 에이전트."""
 import asyncio
 import logging
+from datetime import datetime, timedelta
 from enum import Enum
 from typing import Annotated, Optional
 
@@ -189,10 +190,19 @@ class ElderlyCompanionAgent(Agent):
         return normalized
 
     def _build_instructions(self, ward_context: str = "", call_direction: str = "inbound") -> str:
-        """Build agent instructions with optional context."""
+        """Build agent instructions with optional context and current time."""
+        # Get current KST time (UTC+9)
+        utc_now = datetime.utcnow()
+        kst_now = utc_now + timedelta(hours=9)
+        current_time_kst = kst_now.strftime("%Y년 %m월 %d일 %H시 %M분")
+        current_date_kst = kst_now.strftime("%Y년 %m월 %d일")
+        
         base = (
             "You are a warm, caring AI companion for elderly Korean users.\n"
             "Your name is '소담' (Sodam).\n\n"
+            f"# 현재 시각 (한국 시간)\n"
+            f"- 지금은 {current_time_kst} (KST) 입니다\n"
+            f"- 오늘 날짜: {current_date_kst}\n\n"
             "# CRITICAL RULE: Language\n"
             "- User speaks: Korean (한국어)\n"
             "- You MUST respond: ONLY in Korean (한국어) using respectful 존댓말\n"
@@ -202,9 +212,18 @@ class ElderlyCompanionAgent(Agent):
         )
 
         memory_instruction = (
-            "# Memory Usage\n"
+            "# Memory Usage & Temporal Awareness\n"
             "- When the user mentions family, health, past events, or personal topics, "
             "use the search_memory tool to recall previous conversations\n"
+            "- Retrieved memories include date labels like '[날짜: 2026-01-12 14:30 KST]'\n"
+            "- Interpret these dates naturally in Korean:\n"
+            "  * Today's conversation: '오늘', '아까', '방금'\n"
+            "  * Yesterday: '어제'\n"
+            "  * 2-6 days ago: 'N일 전' (예: '3일 전')\n"
+            "  * 1 week ago: '지난주'\n"
+            "  * 2+ weeks ago: 'N주 전' (예: '2주 전')\n"
+            "  * 1+ months ago: 'N개월 전' (예: '한 달 전', '두 달 전')\n"
+            "- Use these time references naturally: '어제 말씀하신 손자분...', '지난주에 병원 가셨다고 하셨죠?'\n"
             "- Use retrieved memories naturally without explicitly saying '기억을 검색했습니다'\n"
             "- If no relevant memory found, continue conversation naturally\n\n"
         )
@@ -289,14 +308,16 @@ class ElderlyCompanionAgent(Agent):
             if not results:
                 return "관련된 과거 대화가 없습니다."
 
-            # Format results into context
+            # Format results into context with temporal information
             context_parts = []
             for result in results:
                 text = result.get("text", "")
                 similarity = result.get("similarity", 0)
+                created_at = result.get("createdAt", "")
 
-                # Only include results with reasonable similarity (>0.5)
-                if similarity > 0.5 and text:
+                # Only include results with reasonable similarity (>0.4)
+                if similarity > 0.4 and text:
+                    # Text already contains [날짜: ...] prefix from backend
                     context_parts.append(text)
 
             if not context_parts:

--- a/agent/rag_client.py
+++ b/agent/rag_client.py
@@ -240,8 +240,8 @@ class RagClient:
     ) -> str:
         """
         Build a context-aware prompt by combining relevant past conversations
-
-        This is useful for giving the AI agent context about previous conversations
+        
+        Now includes temporal context with KST timestamps for better time awareness
 
         Args:
             ward_id: Ward UUID
@@ -250,7 +250,7 @@ class RagClient:
             context_limit: Number of recent conversations to include
 
         Returns:
-            Formatted context string that can be added to AI prompts
+            Formatted context string with timestamps that can be added to AI prompts
         """
         try:
             # Get both similar and recent contexts
@@ -260,8 +260,7 @@ class RagClient:
 
             context_parts = []
 
-            # Add similar conversations
-            # SAFE: Use .get() to avoid KeyError if API response missing fields
+            # Add similar conversations with timestamps
             if similar_results:
                 context_parts.append("=== 관련 과거 대화 ===")
                 for i, result in enumerate(similar_results, 1):
@@ -269,13 +268,16 @@ class RagClient:
                     similarity_pct = int(result.get("similarity", 0) * 100)
                     # Safe access: skip if text missing (avoid KeyError)
                     text = result.get("text", "")
+                    created_at = result.get("createdAt", "")
+                    
                     if text:  # Only add if text exists
+                        # Format: [{timestamp}] {text}
+                        # Note: text already contains [날짜: ...] prefix from backend
                         context_parts.append(
                             f"\n[관련도 {similarity_pct}%]\n{text}\n"
                         )
 
-            # Add recent context
-            # SAFE: Use .get() to handle missing 'text' field gracefully
+            # Add recent context with timestamps
             if recent_context:
                 context_parts.append("\n=== 최근 대화 내역 ===")
                 for ctx in recent_context:

--- a/agent/rag_client.py
+++ b/agent/rag_client.py
@@ -4,17 +4,83 @@ RAG Client for Python Agent
 Provides utilities to search conversation history and get relevant context
 from PGVector storage (Bedrock Titan Embeddings V2 - 1024 dimensions)
 """
-import os
 import logging
+import os
+from datetime import datetime, timezone
 from typing import List, Dict, Any, Optional
+from zoneinfo import ZoneInfo
 import httpx
 
 from constants import (
+    AGENT_TIMEZONE,
     TIMEOUT_CALL_CONTEXT,
 )
 
 logger = logging.getLogger(__name__)
 _shared_rag_client: Optional["RagClient"] = None
+
+
+def _parse_iso_datetime(value: str) -> Optional[datetime]:
+    if not value:
+        return None
+    try:
+        normalized = value.replace("Z", "+00:00")
+        dt = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _format_months_ago(months: int) -> str:
+    if months == 1:
+        return "한 달 전"
+    if months == 2:
+        return "두 달 전"
+    return f"{months}개월 전"
+
+
+def format_relative_time_ko(
+    iso_timestamp: str,
+    now: Optional[datetime] = None,
+) -> Optional[str]:
+    dt = _parse_iso_datetime(iso_timestamp)
+    if not dt:
+        return None
+
+    try:
+        tz = ZoneInfo(AGENT_TIMEZONE)
+    except Exception:
+        tz = timezone.utc
+
+    dt_local = dt.astimezone(tz)
+    now_local = now.astimezone(tz) if now else datetime.now(tz)
+
+    if now_local < dt_local:
+        return "방금 전"
+
+    diff = now_local - dt_local
+    diff_seconds = int(diff.total_seconds())
+    diff_hours = diff_seconds // 3600
+    diff_days = diff_seconds // 86400
+
+    if diff_hours < 1:
+        return "방금 전"
+    if diff_hours < 24:
+        return f"{diff_hours}시간 전"
+    if diff_days == 1:
+        return "어제"
+    if diff_days < 7:
+        return f"{diff_days}일 전"
+    if diff_days < 14:
+        return "지난주"
+    if diff_days < 60:
+        weeks = diff_days // 7
+        return f"{weeks}주 전"
+
+    months = diff_days // 30
+    return _format_months_ago(months)
 
 
 class RagClient:
@@ -241,7 +307,7 @@ class RagClient:
         """
         Build a context-aware prompt by combining relevant past conversations
         
-        Now includes temporal context with KST timestamps for better time awareness
+        Now includes relative time hints in Asia/Seoul timezone for better time awareness
 
         Args:
             ward_id: Ward UUID
@@ -269,12 +335,14 @@ class RagClient:
                     # Safe access: skip if text missing (avoid KeyError)
                     text = result.get("text", "")
                     created_at = result.get("createdAt", "")
+                    relative_time = format_relative_time_ko(created_at)
                     
                     if text:  # Only add if text exists
-                        # Format: [{timestamp}] {text}
-                        # Note: text already contains [날짜: ...] prefix from backend
+                        time_label = (
+                            f" · {relative_time}" if relative_time else ""
+                        )
                         context_parts.append(
-                            f"\n[관련도 {similarity_pct}%]\n{text}\n"
+                            f"\n[관련도 {similarity_pct}%{time_label}]\n{text}\n"
                         )
 
             # Add recent context with timestamps


### PR DESCRIPTION
✨ 작업 개요
에이전트가 "현재가 언제인지"를 인식하고, RAG로 불러온 과거 기억을 "어제", "지난주"와 같은 상대적 시간 맥락으로 해석할 수 있도록 프롬프트와 로직을 개선했습니다. 또한, 실시간으로 생성되는 개인화 인사말을 안정적으로 수신하기 위해 대기 로직을 최적화했습니다.

📋 주요 변경 사항
1. 시간 인지(Temporal Awareness) 프롬프트 고도화
KST 기준 시각 주입: 세션 시작 시 현재 한국 표준시(KST)를 계산하여 시스템 프롬프트에 동적으로 주입합니다.

시간적 추론 지침 추가: 기억 속의 [날짜: ... KST] 라벨을 분석하여 "오늘/어제/N일 전/지난주" 등 자연스러운 한국어 표현으로 변환하여 발화하도록 유도했습니다.

지침 섹션 확장: # Memory Usage & Temporal Awareness 섹션을 신설하여 AI가 시간 정보를 대화의 핵심 맥락으로 활용하게 했습니다.

2. RAG 검색 임계값 및 맥락 확장
유사도 임계값 완화: 기존 0.5에서 0.4로 하향 조정하여, 직접적인 키워드 일치도가 조금 낮더라도 맥락상 유의미한 과거 대화를 더 풍부하게 참고하도록 개선했습니다.

필드 매핑: API 응답의 createdAt 필드를 수용할 수 있도록 클라이언트 로직을 업데이트했습니다.

3. 인사말 생성 및 수신 안정성 확보
타임아웃 연장: TIMEOUT_GREETING_FETCH 상수를 0.5s에서 5.0s로 상향했습니다.

변경 사유: 단순 캐시 조회를 넘어 백엔드에서 LLM이 실시간으로 인사말을 생성하고 발행(Publish)할 때까지 충분한 대기 시간을 확보하여 개인화 인사말의 성공률을 높였습니다.

🏗 데이터 활용 프로세스
Start: 콜 시작 시 현재 KST 시각 계산 후 LLM에 주입.

Retrieve: 유사도 0.4 이상의 과거 대화(날짜 정보 포함) 검색.

Reasoning: LLM이 [현재 시각]과 [과거 날짜]를 비교하여 "어제 무릎 아프다고 하셨는데..."와 같은 문장 생성.

Greeting: 최대 5초간 대기하며 백엔드에서 생성된 최적의 인사말 수신 후 발화.

🔗 관련 이슈
Closes #17 