### PR TITLE
TTS 초기화 조건화 및 vLLM GPU 사용률 조정

### DIFF
--- a/ai_server/server.py
+++ b/ai_server/server.py
@@ -142,15 +142,17 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         logger.error(f"Failed to load STT service: {e}")
 
-    # Load TTS service (Supertonic-2)
-    try:
-        from services.tts_service import TTSService
-        tts_service = TTSService()
-        await tts_service.initialize()
-        logger.info("TTS Service loaded successfully")
-    except Exception as e:
-        logger.warning(f"Failed to load TTS service: {e}")
-        # TTS is optional - don't block startup
+    # Load TTS service (Supertonic-2) - optional, disabled by default
+    if os.getenv("ENABLE_TTS", "false").lower() == "true":
+        try:
+            from services.tts_service import TTSService
+            tts_service = TTSService()
+            await tts_service.initialize()
+            logger.info("TTS Service loaded successfully")
+        except Exception as e:
+            logger.warning(f"Failed to load TTS service: {e}")
+    else:
+        logger.info("TTS Service disabled (ENABLE_TTS != true)")
 
     # Load Turn Detector service
     try:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -17,7 +17,7 @@ services:
       - --max-model-len
       - "32768"
       - --gpu-memory-utilization
-      - "0.65"
+      - "0.55"
       - --dtype
       - half
       - --trust-remote-code


### PR DESCRIPTION
## 요약
ENABLE_TTS가 true일 때만 TTS 초기화를 수행하고, vLLM GPU 메모리 사용률을 낮춥니다.

## 변경 사항
- ai_server/server.py: TTS 초기화 ENABLE_TTS 게이트 추가
- docker-compose.dev.yml: vLLM --gpu-memory-utilization 0.65 → 0.55

## 테스트
- 미실행 (설정 변경)

## 이슈
- 관련 이슈: #52